### PR TITLE
moved goal builder to its own page, played with background colours from bootstrap

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,5 @@
 @import "components/index";
 @import "pages/index";
 @import "pages/calculator_builder"
+
+

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -2,9 +2,10 @@
 
 // For example:
 $red: #FD1015;
-$blue: #167FFB;
+$blue: #415873;
 $yellow: #FFC65A;
-$orange: #E67E22;
+$orange: #FF6F5E;
 $green: #1EDD88;
 $gray: #0E0000;
 $light-gray: #F4F4F4;
+$uporange: #FF6F5E;

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -21,4 +21,10 @@ class PagesController < ApplicationController
 
   def calculator
   end
+
+  def goal_builder
+    @goal = Goal.new
+    @goal.build_reason
+    @goals = Goal.all
+  end
 end

--- a/app/views/pages/dashboard.html.erb
+++ b/app/views/pages/dashboard.html.erb
@@ -1,10 +1,13 @@
-<h1>dashboard</h1>
+<div class="p-3 mb-2 bg-primary">
+<h1>Dashboard</h1>
+
 <div class="card mb-3 mx-auto col-md-4 py-3 shadow-sm rounded">
-  <%= render "goals_builder" %>
+  <h2><%= link_to "Build A Goal", goal_builder_path, class: "btn btn-warning" %></h2>
 </div>
+
 <div class="card mb-3 mx-auto col-md-4 py-3 shadow-sm rounded">
   <h2>Your Goals</h2>
   <%= render "goal_summary" %>
 </div>
 
-
+</div>

--- a/app/views/pages/goal_builder.html.erb
+++ b/app/views/pages/goal_builder.html.erb
@@ -1,0 +1,34 @@
+<div class="p-3 mb-2 bg-primary">
+
+  <div class="card mb-3 mx-auto col-md-4 py-3 shadow-sm rounded">
+
+    <%= simple_form_for @goal do |f| %>
+    <% @goal_names = [] %>
+    <% @goals.each do |goal| %>
+      <% if goal.user_id == current_user.id %>
+        <% @goal_names << goal.name %>
+      <% end %>
+    <% end %>
+    <select class="form-control select required" id="goal_form" name="goal[name]">
+      <% UpApi.goal_saver(current_user.api_key).each do |key, value|%>
+        <% if @goal_names.include? key %>
+          <% next %>
+        <% else %>
+          <option value="<%= key %>" data-balance="<%= value %>"><%= key %></option>
+        <% end %>
+      <% end %>
+    </select>
+                     <!--   f.input :name, as: :select, collection: UpApi.goal_saver(current_user.api_key), prompt: 'Select Saver', label: "Please choose your UP Saver account!", :input_html => { id: "select" } -->
+                        <p>Your Balance:</p>
+                        <p id="result"></p>
+                      <%= f.input :amount, label: "How much do you want to save?", :input_html => { id: "amount" }%>
+                      <%= f.input :due_date, id:'goal_due_date', as: :string,label: "When do you want to save it by?" %>
+                      <p id="weeks"></p>
+                      <%= f.simple_fields_for :reason, Reason.new do |p| %>
+                        <%= p.input :description, label: "Why are you saving for this goal?", placeholder: ["I need to avoid...a mid-life crisis", "I want to people to...be jealous of me", "I strive to be...financially secure"].sample%>
+                        <% end %>
+                      <%= f.submit "Hell Yeah", class: "btn btn-warning"%>
+                    <% end %>
+
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
 
   get '/calculator', to: 'pages#calculator'
 
+  get '/goal_builder', to: 'pages#goal_builder'
 
   get '/dashboard', to: 'pages#dashboard'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
- Moved our Goals Builder from the Dashboard and onto its own page. Just had to create a new route, update the controller, and create a new page.
- The _goals_builder partial still exists, didn't delete it, just not rendering it on this page now.
- I changed two stock colours on Bootstrap so we could use it on our colours. Maybe not the best way but was ok to play with
- I updated primary (blue) to the UP dark grey, and I updated warning (orange) to the UP orange.
- You'll notice on the Dashboard and Goal Builder pages up in the top div it calls out the bg-primary to get the colour.

There are probably better ways to do this but it's a start. I'd like to look at the typeface next :)